### PR TITLE
Linking to the actual COPYINg file

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@ libarchive - C library and command-line tools for reading and writing tar, cpio,
   </p>
   <h2>License</h2>
   <p>
-    <a href="http://www.opensource.org/licenses/bsd-license.php">New BSD License</a>
+    <a href="https://raw.githubusercontent.com/libarchive/libarchive/master/COPYING">New BSD License</a>
   </p>
   <h2>Issue Tracker</h2>
   <p>


### PR DESCRIPTION
... rather than to some template. This provides a direct access to the licensing terms