### PR TITLE
Use https as protocol for suggested cloning

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@ libarchive - C library and command-line tools for reading and writing tar, cpio,
     You can also clone the project with <a href="http://git-scm.com">Git</a>
     by running:
     <pre>
-      $ git clone git://github.com/libarchive/libarchive
+      $ git clone https://github.com/libarchive/libarchive
     </pre>
   </p>
   <div class="footer">


### PR DESCRIPTION
GitHub allows to clone the repository both over Git specific protocol and HTTPS. In the latter case, content integrity is ensured by the TLS connection as well as Git's own, making MITM harder.

Also, HTTPS is more likely to pass through corporate proxies and firewalls.